### PR TITLE
Fix STATIC_URL duplication

### DIFF
--- a/myselfservice/config/settings.py
+++ b/myselfservice/config/settings.py
@@ -182,9 +182,7 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/4.2/howto/static-files/
 
-STATIC_URL = "static/"
 STATICFILES_DIRS = [BASE_DIR / 'static']
-
 STATIC_ROOT = BASE_DIR / 'staticfiles'
 STATIC_URL = '/static/'
 


### PR DESCRIPTION
## Summary
- clean up static files configuration

## Testing
- `pytest -q` *(fails: ModuleNotFoundError / network issues)*

------
https://chatgpt.com/codex/tasks/task_e_686176e023c88330b0b6f46d5199782a