### PR TITLE
Fix cleanup events path comment

### DIFF
--- a/myselfservice/apps/events/management/commands/cleanup_events.py
+++ b/myselfservice/apps/events/management/commands/cleanup_events.py
@@ -1,4 +1,4 @@
-# apps/guests/management/commands/cleanup_guests.py 
+# apps/events/management/commands/cleanup_events.py
 from django.core.management.base import BaseCommand
 from django.utils import timezone
 from apps.events.models import Event


### PR DESCRIPTION
## Summary
- correct first line in cleanup events command to reflect file path

## Testing
- `python -m py_compile myselfservice/apps/events/management/commands/cleanup_events.py`


------
https://chatgpt.com/codex/tasks/task_e_6861771687d08330bf02c6b0cd640b60