### PR TITLE
Fix readme wording

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -45,7 +45,7 @@ cd docker/dev
 Das `init.sh` Script automatisiert die initiale Einrichtung:
 
 - Erstellt eine `.env` Datei aus der `env.example`
-- ruft ein Script `openldap/generate_bootstrap.sh` auf um OpenLDAP zu vorzubereiten
+- ruft ein Script `openldap/generate_bootstrap.sh` auf, um OpenLDAP vorzubereiten
 
 ### 3. Start des Systems und Nutzung
 ```bash


### PR DESCRIPTION
## Summary
- fix wording about bootstrapping OpenLDAP

## Testing
- `pytest docker/dev/tests/test_auth.py -q` *(fails: ModuleNotFoundError and other missing resources)*

------
https://chatgpt.com/codex/tasks/task_e_6861774187808330975e36d920f43940